### PR TITLE
Several improvements:

### DIFF
--- a/nisqa/NISQA_lib.py
+++ b/nisqa/NISQA_lib.py
@@ -2083,6 +2083,7 @@ class SpeechQualityDataset(Dataset):
         double_ended=False,
         filename_column_ref=None,
         dim=False,
+        n_channel=0
         ):
 
         self.df = df
@@ -2105,7 +2106,8 @@ class SpeechQualityDataset(Dataset):
         self.ms_fmax = ms_fmax
         self.double_ended = double_ended
         self.dim = dim
-    
+        self.n_channel = n_channel
+
         # if True load all specs to memory
         self.to_memory = False
         if to_memory:
@@ -2146,7 +2148,8 @@ class SpeechQualityDataset(Dataset):
                 hop_length=self.ms_hop_length,
                 win_length=self.ms_win_length,
                 n_mels=self.ms_n_mels,
-                fmax=self.ms_fmax
+                fmax=self.ms_fmax,
+                n_channel=self.n_channel
                 )   
             
             if self.double_ended:
@@ -2287,13 +2290,17 @@ def get_librosa_melspec(
     hop_length=80, 
     win_length=170,
     n_mels=32,
-    fmax=16e3):
+    fmax=16e3,
+    n_channel=0
+    ):
     '''
     Calculate mel-spectrograms with Librosa.
     '''    
     # Calc spec
     try:
-        y, sr = lb.load(file_path, sr=sr)
+        y, sr = lb.load(file_path, sr=sr, mono=False)
+        if len(y.shape) > 1:
+            y = y[n_channel, :]
     except:
         raise ValueError('Could not load file {}'.format(file_path))
     

--- a/nisqa/NISQA_model.py
+++ b/nisqa/NISQA_model.py
@@ -1016,10 +1016,8 @@ class nisqaModel(object):
                 self.args['data_dir'] = args_new['data_dir']
                 self.args['input_dir'] = os.getcwd()
                 self.args['csv_deg'] = args_new['csv_deg']
-                if 'csv_ref' in args_new:
-                    self.args['csv_ref'] = args_new['csv_ref']     
-                else:
-                    self.args['csv_ref'] = None
+                self.args['csv_ref'] = args_new.get('csv_ref', None)
+
                 if 'csv_con' in args_new:
                     self.args['csv_con'] = args_new['csv_con']                
                 if args_new['bs']:
@@ -1030,7 +1028,7 @@ class nisqaModel(object):
             else:
                 raise NotImplementedError('Mode not available')                        
             
-        self.args['n_channel'] = args_new['n_channel']
+        self.args['n_channel'] = args_new.get('n_channel', 0)
 
         if self.args['model']=='NISQA_DIM':
             self.args['dim'] = True

--- a/nisqa/NISQA_model.py
+++ b/nisqa/NISQA_model.py
@@ -16,7 +16,7 @@ import torch
 import torch.nn as nn
 from torch import optim
 from torch.utils.data import DataLoader
-import nisqa.NISQA_lib as NL
+from . import NISQA_lib as NL
         
 class nisqaModel(object):
     '''
@@ -78,7 +78,8 @@ class nisqaModel(object):
                 index=False)
             
         print(self.ds_val.df.to_string(index=False))
-        
+        return self.ds_val.df
+
     def _train_mos(self):
         '''
         Trains speech quality model.
@@ -772,7 +773,8 @@ class nisqaModel(object):
             ms_fmax = self.args['ms_fmax'],
             double_ended = self.args['double_ended'],
             dim = self.args['dim'],
-            filename_column_ref = None,                        
+            filename_column_ref = None,
+            n_channel=self.args['n_channel'],
             )
         
         
@@ -802,8 +804,9 @@ class nisqaModel(object):
             ms_fmax = self.args['ms_fmax'],
             double_ended = self.args['double_ended'],
             dim = self.args['dim'],
-            filename_column_ref = None,                        
-            )
+            filename_column_ref = None,
+            n_channel=self.args['n_channel'],
+        )
                 
         
     def _loadDatasetsCSVpredict(self):         
@@ -841,8 +844,9 @@ class nisqaModel(object):
             ms_fmax = self.args['ms_fmax'],
             double_ended = self.args['double_ended'],
             dim = self.args['dim'],
-            filename_column_ref = self.args['csv_ref'],                        
-            )
+            filename_column_ref = self.args['csv_ref'],
+            n_channel=self.args['n_channel'],
+        )
 
         
     def _loadDatasetsCSV(self):    
@@ -893,8 +897,9 @@ class nisqaModel(object):
             ms_fmax = self.args['ms_fmax'],
             double_ended = self.args['double_ended'],
             dim = self.args['dim'],
-            filename_column_ref = self.args['csv_ref'],            
-            )
+            filename_column_ref = self.args['csv_ref'],
+            n_channel=self.args['n_channel'],
+        )
 
         self.ds_val = NL.SpeechQualityDataset(
             df_val,
@@ -917,6 +922,7 @@ class nisqaModel(object):
             double_ended = self.args['double_ended'],
             dim = self.args['dim'],
             filename_column_ref = self.args['csv_ref'],                        
+            n_channel = self.args['n_channel'],
             )
 
         self.runinfos['ds_train_len'] = len(self.ds_train)
@@ -1024,6 +1030,8 @@ class nisqaModel(object):
             else:
                 raise NotImplementedError('Mode not available')                        
             
+        self.args['n_channel'] = args_new['n_channel']
+
         if self.args['model']=='NISQA_DIM':
             self.args['dim'] = True
         else:


### PR DESCRIPTION
- used relative import, in case NISQA is used as a sub-module in an existing project
- nisqaModel.predict(self) returns the dataframe for further usage in Python w/o reading CSV
- In case the input wave/flac-file has more than one channel, the corresponding channel index has to be added to the parameters.
- modified: librosa.load(..., mono=False) -> if input file has more than 1 channel